### PR TITLE
chore(gitignore): ignore AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 githubrunner_exporter
 bin/
 coverage/
+
+AGENTS.md


### PR DESCRIPTION
## Summary
- add AGENTS.md to .gitignore
- keep AGENTS guidance files out of repository history

## Validation
- run git status --short and confirm AGENTS.md is ignored